### PR TITLE
Add base URL path support

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -270,6 +270,10 @@ By default, this is not enabled. You can enable this by setting it to `true`.
 
 This is the base path used to resolve other paths, particularly for serving static files. Must be an absolute path. This is rarely needed because the default of using the current working directory is usually sufficient.
 
+### MESOP_BASE_URL_PATH
+
+Base URL path for serving the Mesop application. Set this if your app is served from a non-root path (e.g. `/myapp`). All HTTP routes, static assets, and API calls will be prefixed with this path. The value must start with a slash but should not include a trailing slash.
+
 ### MESOP_HTTP_CACHE_JS_BUNDLE
 
 Enables HTTP caching for the main JS bundle (i.e. prod_bundle.js) served by Mesop. This minimizes unnecessary HTTP requests for the JS bundle.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -187,6 +187,16 @@ docker build -t mesop-app . && docker run -d -p 8080:8080 mesop-app
 
 You should now be able to view your Mesop app at http://localhost:8080.
 
+### Deploying behind a reverse proxy
+
+If you serve your Mesop app behind a reverse proxy at a custom path, set `MESOP_BASE_URL_PATH` to that path. For example, if the proxy routes requests under `/myapp` to Mesop, run the server with:
+
+```sh
+MESOP_BASE_URL_PATH=/myapp docker-compose up -d
+```
+
+All routes, including the UI endpoint and static assets, will then be served from `/myapp`.
+
 
 ## Hugging Face Spaces
 

--- a/mesop/components/html/html.ts
+++ b/mesop/components/html/html.ts
@@ -15,6 +15,7 @@ import {
 import {HtmlType} from 'mesop/mesop/components/html/html_jspb_proto_pb/mesop/components/html/html_pb';
 import {formatStyle} from '../../web/src/utils/styles';
 import {setIframeSrc} from '../../web/src/safe_iframe/safe_iframe';
+import {prefixBasePath} from '../../web/src/utils/base_path';
 
 @Component({
   selector: 'mesop-html',
@@ -70,7 +71,7 @@ export class HtmlComponent {
     }
 
     const iframe = this.iframe.nativeElement as HTMLIFrameElement;
-    setIframeSrc(iframe, '/sandbox_iframe.html');
+    setIframeSrc(iframe, prefixBasePath('/sandbox_iframe.html'));
     iframe.onload = () => {
       iframe.contentWindow!.postMessage(
         {

--- a/mesop/env/env.py
+++ b/mesop/env/env.py
@@ -23,11 +23,21 @@ if MESOP_APP_BASE_PATH:
       f"MESOP_APP_BASE_PATH is not a valid directory: {MESOP_APP_BASE_PATH}"
     )
 
+MESOP_BASE_URL_PATH = os.environ.get("MESOP_BASE_URL_PATH", "").strip()
+if MESOP_BASE_URL_PATH:
+  if not MESOP_BASE_URL_PATH.startswith("/"):
+    raise MesopDeveloperException("MESOP_BASE_URL_PATH must start with a slash")
+  MESOP_BASE_URL_PATH = MESOP_BASE_URL_PATH.rstrip("/")
+
 
 def get_app_base_path() -> str:
   if not MESOP_APP_BASE_PATH:
     return os.getcwd()
   return MESOP_APP_BASE_PATH
+
+
+def get_base_url_path() -> str:
+  return MESOP_BASE_URL_PATH
 
 
 MESOP_PROD_UNREDACTED_ERRORS = (

--- a/mesop/server/server.py
+++ b/mesop/server/server.py
@@ -17,6 +17,7 @@ import mesop.protos.ui_pb2 as pb
 from mesop.component_helpers import diff_component
 from mesop.env.env import (
   MESOP_APP_BASE_PATH,
+  MESOP_BASE_URL_PATH,
   MESOP_PROD_UNREDACTED_ERRORS,
   MESOP_WEBSOCKETS_ENABLED,
 )
@@ -32,12 +33,13 @@ from mesop.server.server_utils import (
   get_static_url_path,
   is_same_site,
   make_sse_response,
+  prefix_base_url,
   serialize,
 )
 from mesop.utils.url_utils import remove_url_query_param
 from mesop.warn import warn
 
-UI_PATH = "/__ui__"
+UI_PATH = prefix_base_url("/__ui__")
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +52,8 @@ def configure_flask_app(
 
   if MESOP_APP_BASE_PATH:
     logger.info(f"MESOP_APP_BASE_PATH set to {MESOP_APP_BASE_PATH}")
+  if MESOP_BASE_URL_PATH:
+    logger.info(f"MESOP_BASE_URL_PATH set to {MESOP_BASE_URL_PATH}")
 
   if MESOP_PROD_UNREDACTED_ERRORS and prod_mode:
     logger.info(

--- a/mesop/server/server_debug_routes.py
+++ b/mesop/server/server_debug_routes.py
@@ -3,10 +3,11 @@ import time
 from flask import Flask, Response, request
 
 from mesop.runtime import runtime
+from mesop.server.server_utils import prefix_base_url
 
 
 def configure_debug_routes(flask_app: Flask):
-  @flask_app.route("/__hot-reload__")
+  @flask_app.route(prefix_base_url("/__hot-reload__"))
   def hot_reload() -> Response:
     counter = int(request.args["counter"])
     while True:

--- a/mesop/server/server_utils.py
+++ b/mesop/server/server_utils.py
@@ -10,10 +10,33 @@ from flask import Response
 from werkzeug.security import safe_join
 
 import mesop.protos.ui_pb2 as pb
-from mesop.env.env import get_app_base_path
+from mesop.env.env import MESOP_BASE_URL_PATH, get_app_base_path
 from mesop.exceptions import MesopDeveloperException
 from mesop.runtime import runtime
 from mesop.server.config import app_config
+
+
+def prefix_base_url(path: str) -> str:
+  base = MESOP_BASE_URL_PATH.rstrip("/")
+  if not path.startswith("/"):
+    path = "/" + path
+  if base:
+    if path == "/":
+      return base + "/"
+    return base + path
+  return path
+
+
+def remove_base_url_path(path: str) -> str:
+  base = MESOP_BASE_URL_PATH.rstrip("/")
+  if base and path.startswith(base):
+    path = path[len(base) :]
+    if not path:
+      return "/"
+    if not path.startswith("/"):
+      path = "/" + path
+  return path
+
 
 LOCALHOSTS = (
   # For IPv4 localhost
@@ -159,7 +182,7 @@ def get_static_url_path() -> str | None:
   if not static_url_path.endswith("/"):
     static_url_path += "/"
 
-  return static_url_path
+  return prefix_base_url(static_url_path)
 
 
 def get_favicon() -> str | None:

--- a/mesop/web/src/utils/base_path.ts
+++ b/mesop/web/src/utils/base_path.ts
@@ -1,0 +1,13 @@
+export function prefixBasePath(path: string): string {
+  const base = (window as any).__MESOP_BASE_URL_PATH__ as string | undefined;
+  if (!base) {
+    return path;
+  }
+  if (!path.startsWith('/')) {
+    path = '/' + path;
+  }
+  if (base.endsWith('/')) {
+    return base + path.substring(1);
+  }
+  return base + path;
+}


### PR DESCRIPTION
This pull request introduces support for serving the Mesop application from a custom base URL path, enabling deployment behind reverse proxies or non-root paths. The changes include updates to environment variables, server logic, client-side utilities, and documentation to handle the new `MESOP_BASE_URL_PATH` configuration.

### Configuration and Documentation Updates:
* Added a new environment variable, `MESOP_BASE_URL_PATH`, to specify a base URL path for serving the application. Updated the configuration documentation (`docs/api/config.md`) and deployment guide (`docs/guides/deployment.md`) to explain its usage. [[1]](diffhunk://#diff-6c4ebfe0aa9ec8557f1bdbe5eeb054a13681577ce99eb0029a82acf1676e4591R273-R276) [[2]](diffhunk://#diff-a64b8a24a607a69d878001e87b24bc5435e4e00d05fe71f467f4e06f3f4bca8cR190-R199)

### Backend Changes:
* Introduced `prefix_base_url` and `remove_base_url_path` utility functions in `mesop/server/server_utils.py` to handle URL path prefixing and removal based on `MESOP_BASE_URL_PATH`. [[1]](diffhunk://#diff-71a421f564aa2d4a5afb1af31bb6b25004fe0bb5c96b9a073c84c612cf122038L13-R40) [[2]](diffhunk://#diff-71a421f564aa2d4a5afb1af31bb6b25004fe0bb5c96b9a073c84c612cf122038L162-R185)
* Updated Flask route definitions across various server files (e.g., `server.py`, `server_debug_routes.py`, `static_file_serving.py`) to use `prefix_base_url` for consistent URL path handling. [[1]](diffhunk://#diff-a7deda25f91db6b0c9d70f9bdeeb9868be068c24a63bb4b5957c34c37f049cbaR36-R42) [[2]](diffhunk://#diff-28a35684489ac58311a49e03e4eb78290908610e184eacde881d4ec8e99ec2f9R6-R10) [[3]](diffhunk://#diff-af4fe7ee2dbe81359f65e957b13dd9ef25d3941cd3952ae6e1d9143e90bd4e1dL114-R137)
* Adjusted security headers and CSP configurations in `static_file_serving.py` to account for the base URL path. [[1]](diffhunk://#diff-af4fe7ee2dbe81359f65e957b13dd9ef25d3941cd3952ae6e1d9143e90bd4e1dL257-R270) [[2]](diffhunk://#diff-af4fe7ee2dbe81359f65e957b13dd9ef25d3941cd3952ae6e1d9143e90bd4e1dL349-R371)

### Frontend Changes:
* Added a `prefixBasePath` utility function in `mesop/web/src/utils/base_path.ts` for client-side URL path prefixing. Updated components and services (e.g., `html.ts`, `channel.ts`) to use this function for consistent path handling. [[1]](diffhunk://#diff-aaffddef9cbca3aa6c7edbffaf1188accfbdd1e566e4165337e6930f6dd592b4R18) [[2]](diffhunk://#diff-b53473e334c6c0088bede4e2a8a4a9483d380f676b600b607d80b26eb31f1037R17) [[3]](diffhunk://#diff-4eeda36cba480fa465d14a6158bec0cae6745ccdf2bdaed345801819e11dee54R1-R13)
* Modified the client-side path logic in `channel.ts` to strip the base URL path from requests dynamically.

### Application Behavior:
* Updated the `retrieve_index_html` function in `static_file_serving.py` to dynamically set the `<base>` HTML tag and the `window.__MESOP_BASE_URL_PATH__` global variable for client-side compatibility. [[1]](diffhunk://#diff-af4fe7ee2dbe81359f65e957b13dd9ef25d3941cd3952ae6e1d9143e90bd4e1dL60-R77) [[2]](diffhunk://#diff-af4fe7ee2dbe81359f65e957b13dd9ef25d3941cd3952ae6e1d9143e90bd4e1dR110)

These changes ensure that all HTTP routes, static assets, and API calls are correctly prefixed with the specified base URL path, improving flexibility for deployments in non-root contexts.