### PR TITLE
Update prefix_base_url

### DIFF
--- a/mesop/server/server_utils.py
+++ b/mesop/server/server_utils.py
@@ -3,7 +3,8 @@ import json
 import os
 import secrets
 import urllib.parse as urlparse
-from typing import Any, Generator, Iterable
+from collections.abc import Generator, Iterable
+from typing import Any
 from urllib import request as urllib_request
 
 from flask import Response
@@ -20,11 +21,7 @@ def prefix_base_url(path: str) -> str:
   base = MESOP_BASE_URL_PATH.rstrip("/")
   if not path.startswith("/"):
     path = "/" + path
-  if base:
-    if path == "/":
-      return base + "/"
-    return base + path
-  return path
+  return base + path if base else path
 
 
 def remove_base_url_path(path: str) -> str:


### PR DESCRIPTION
This pull request includes updates to `mesop/server/server_utils.py` that improve code clarity and modernize imports. The changes focus on simplifying logic and adhering to updated Python standards.

### Code modernization:
* Replaced deprecated `typing` imports (`Generator`, `Iterable`) with their counterparts from `collections.abc` to align with Python's updated typing guidelines. (`[mesop/server/server_utils.pyL6-R7](diffhunk://#diff-71a421f564aa2d4a5afb1af31bb6b25004fe0bb5c96b9a073c84c612cf122038L6-R7)`)

### Code simplification:
* Refactored the `prefix_base_url` function to use a single-line conditional expression, simplifying the logic for appending the base URL to a given path. (`[mesop/server/server_utils.pyL23-R24](diffhunk://#diff-71a421f564aa2d4a5afb1af31bb6b25004fe0bb5c96b9a073c84c612cf122038L23-R24)`)