### PR TITLE
Fix remove_base_url_path

### DIFF
--- a/mesop/server/server_utils.py
+++ b/mesop/server/server_utils.py
@@ -3,7 +3,8 @@ import json
 import os
 import secrets
 import urllib.parse as urlparse
-from typing import Any, Generator, Iterable
+from collections.abc import Generator, Iterable
+from typing import Any
 from urllib import request as urllib_request
 
 from flask import Response
@@ -28,7 +29,7 @@ def prefix_base_url(path: str) -> str:
 
 
 def remove_base_url_path(path: str) -> str:
-  base = MESOP_BASE_URL_PATH.rstrip("/")
+  base = MESOP_BASE_URL_PATH
   if base and path.startswith(base):
     path = path[len(base) :]
     if not path:


### PR DESCRIPTION
This pull request includes updates to the `mesop/server/server_utils.py` file to improve type imports and adjust the handling of the `MESOP_BASE_URL_PATH` variable in the `remove_base_url_path` function.

### Type import updates:
* Replaced `typing.Generator` and `typing.Iterable` with `collections.abc.Generator` and `collections.abc.Iterable` to align with Python's updated type hinting standards. (`[mesop/server/server_utils.pyL6-R7](diffhunk://#diff-71a421f564aa2d4a5afb1af31bb6b25004fe0bb5c96b9a073c84c612cf122038L6-R7)`)

### Function adjustment:
* Modified the `remove_base_url_path` function to remove the redundant `.rstrip("/")` call on `MESOP_BASE_URL_PATH`, ensuring the base URL path is used as-is. (`[mesop/server/server_utils.pyL31-R32](diffhunk://#diff-71a421f564aa2d4a5afb1af31bb6b25004fe0bb5c96b9a073c84c612cf122038L31-R32)`)