### PR TITLE
Fix base url handling

### DIFF
--- a/mesop/server/server_utils.py
+++ b/mesop/server/server_utils.py
@@ -17,7 +17,7 @@ from mesop.server.config import app_config
 
 
 def prefix_base_url(path: str) -> str:
-  base = MESOP_BASE_URL_PATH.rstrip("/")
+  base = MESOP_BASE_URL_PATH
   if not path.startswith("/"):
     path = "/" + path
   if base:
@@ -28,7 +28,7 @@ def prefix_base_url(path: str) -> str:
 
 
 def remove_base_url_path(path: str) -> str:
-  base = MESOP_BASE_URL_PATH.rstrip("/")
+  base = MESOP_BASE_URL_PATH
   if base and path.startswith(base):
     path = path[len(base) :]
     if not path:


### PR DESCRIPTION
This pull request includes a minor update to the `server_utils.py` file to simplify the handling of the `MESOP_BASE_URL_PATH` variable by removing the use of `rstrip("/")` in two functions.

Simplification of base URL handling:

* [`mesop/server/server_utils.py`](diffhunk://#diff-71a421f564aa2d4a5afb1af31bb6b25004fe0bb5c96b9a073c84c612cf122038L20-R20): Updated the `prefix_base_url` and `remove_base_url_path` functions to use `MESOP_BASE_URL_PATH` directly, without stripping trailing slashes. [[1]](diffhunk://#diff-71a421f564aa2d4a5afb1af31bb6b25004fe0bb5c96b9a073c84c612cf122038L20-R20) [[2]](diffhunk://#diff-71a421f564aa2d4a5afb1af31bb6b25004fe0bb5c96b9a073c84c612cf122038L31-R31)