### PR TITLE
Add base path tests

### DIFF
--- a/mesop/server/server_utils.py
+++ b/mesop/server/server_utils.py
@@ -3,7 +3,8 @@ import json
 import os
 import secrets
 import urllib.parse as urlparse
-from typing import Any, Generator, Iterable
+from collections.abc import Generator, Iterable
+from typing import Any
 from urllib import request as urllib_request
 
 from flask import Response
@@ -28,7 +29,7 @@ def prefix_base_url(path: str) -> str:
 
 
 def remove_base_url_path(path: str) -> str:
-  base = MESOP_BASE_URL_PATH.rstrip("/")
+  base = MESOP_BASE_URL_PATH
   if base and path.startswith(base):
     path = path[len(base) :]
     if not path:

--- a/mesop/server/server_utils_test.py
+++ b/mesop/server/server_utils_test.py
@@ -1,0 +1,36 @@
+import importlib
+from unittest.mock import patch
+
+import mesop.server.server_utils as su
+from mesop.env import env
+
+
+def reload_utils():
+  importlib.reload(su)
+
+
+def test_remove_base_url_path_no_base():
+  with patch.object(env, "MESOP_BASE_URL_PATH", ""):
+    reload_utils()
+    assert su.remove_base_url_path("/foo") == "/foo"
+
+
+def test_remove_base_url_path_with_base():
+  with patch.object(env, "MESOP_BASE_URL_PATH", "/base"):
+    reload_utils()
+    assert su.remove_base_url_path("/base/foo") == "/foo"
+    assert su.remove_base_url_path("/base") == "/"
+    assert su.remove_base_url_path("/base/") == "/"
+
+
+def test_prefix_base_url_with_base():
+  with patch.object(env, "MESOP_BASE_URL_PATH", "/base"):
+    reload_utils()
+    assert su.prefix_base_url("/foo") == "/base/foo"
+    assert su.prefix_base_url("foo") == "/base/foo"
+
+
+def test_prefix_base_url_no_base():
+  with patch.object(env, "MESOP_BASE_URL_PATH", ""):
+    reload_utils()
+    assert su.prefix_base_url("/foo") == "/foo"

--- a/mesop/web/src/utils/__tests__/base_path_test.ts
+++ b/mesop/web/src/utils/__tests__/base_path_test.ts
@@ -1,0 +1,24 @@
+import {test} from 'node:test';
+import assert from 'node:assert';
+
+import {prefixBasePath} from '../base_path';
+
+test('returns original path when no base is set', () => {
+  global.window = {};
+  assert.strictEqual(prefixBasePath('/foo'), '/foo');
+});
+
+test('adds base path to absolute path', () => {
+  global.window = {__MESOP_BASE_URL_PATH__: '/base'};
+  assert.strictEqual(prefixBasePath('/foo'), '/base/foo');
+});
+
+test('adds base path to relative path', () => {
+  global.window = {__MESOP_BASE_URL_PATH__: '/base'};
+  assert.strictEqual(prefixBasePath('foo'), '/base/foo');
+});
+
+test('handles base path ending with slash', () => {
+  global.window = {__MESOP_BASE_URL_PATH__: '/base/'};
+  assert.strictEqual(prefixBasePath('/foo'), '/base/foo');
+});


### PR DESCRIPTION
This pull request includes updates to the handling of base URL paths in the server and client code, as well as improvements to type imports for compatibility with modern Python standards. Additionally, new unit tests have been added to ensure the correctness of the updated functions.

### Updates to base URL path handling:

* [`mesop/server/server_utils.py`](diffhunk://#diff-71a421f564aa2d4a5afb1af31bb6b25004fe0bb5c96b9a073c84c612cf122038L31-R32): Simplified the `remove_base_url_path` function by removing the unnecessary `.rstrip("/")` call on `MESOP_BASE_URL_PATH`. This ensures consistent handling of the base URL path.

* [`mesop/server/server_utils_test.py`](diffhunk://#diff-afef9d6e372a8c2e14f71e4e9cb933af07b33cba19924c65094ec39378b037f3R1-R36): Added unit tests for `remove_base_url_path` and `prefix_base_url` to verify behavior with and without a base URL path. These tests ensure correctness in various scenarios, such as paths with trailing slashes.

* [`mesop/web/src/utils/__tests__/base_path_test.ts`](diffhunk://#diff-7b686687ea95b19c1bf9a111f03c15ad72c2291608c6068859c9af710f084168R1-R24): Added client-side unit tests for the `prefixBasePath` function to validate its behavior when adding a base path to absolute and relative paths, as well as handling edge cases like trailing slashes.

### Improvements to type imports:

* [`mesop/server/server_utils.py`](diffhunk://#diff-71a421f564aa2d4a5afb1af31bb6b25004fe0bb5c96b9a073c84c612cf122038L6-R7): Updated imports to use `collections.abc` for `Generator` and `Iterable` instead of `typing`, aligning with modern Python standards for type annotations.